### PR TITLE
Adds release workflow

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -220,7 +220,7 @@ TBD - need to hash out a bit more of this process.
 
 With GitHub actions, our workflow for publishing new version to NPM are automatic! Here are the steps you need to take to ensure a release occurs:
 
-1. In a commit, use the [NPM `version` command](https://docs.npmjs.com/cli/version) to update the package to the next version:
+1. In a new branch, use the [NPM `version` command](https://docs.npmjs.com/cli/version) to update the package to the next version. This will automatically update the `package.json` and create a commit with an associated tag:
 
    ```sh
    npm version patch
@@ -228,7 +228,7 @@ With GitHub actions, our workflow for publishing new version to NPM are automati
    # npm version major
    ```
 
-2. Create a new pull request with the commit. Be sure to follow the steps in the [Contribute Code](#contribute-code) section.
+2. Create a new pull request with your branch. Be sure to follow the steps in the [Contribute Code](#contribute-code) section.
 
 3. If the pull request is merged successfully, the [`Release` action](./workflows/release.yml) should publish the latest version to NPM and create a new release.
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -17,6 +17,7 @@
   - [Clean Up Issues and PRs](#clean-up-issues-and-prs)
   - [Review Pull Requests](#review-pull-requests)
   - [Merge Pull Requests](#merge-pull-requests)
+  - [Release Workflow](#release-workflow)
   - [Tag a Release](#tag-a-release)
 - Add a Guide Like This One [To My Project](#attribution)?
 
@@ -216,9 +217,20 @@ Some notes:
 
 TBD - need to hash out a bit more of this process.
 
-## Tag A Release
+## Release Workflow
 
-TBD - need to hash out a bit more of this process. The most important bit here is probably that all tests must pass, and tags must use [semver](https://semver.org).
+With GitHub actions, our workflow for publishing new version to NPM are automatic! Here are the steps you need to take to ensure a release occurs:
+
+1. In a commit, update your [`package.json`](../package.json) and [`package-lock.json`](../package-lock.json) with the next version. We use [semver](https://semver.org) for versioning:
+
+```diff
+- "version": "1.0.0",
++ "version": "1.0.1", # minor update
+```
+
+2. Create a new pull request with the commit. Be sure to follow the steps in the [Contribute Code](#contribute-code) section.
+
+3. If the pull request is merged successfully, the `Release` action should publish the latest version to NPM and create a new release.
 
 ## Attribution
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -221,12 +221,22 @@ TBD - need to hash out a bit more of this process.
 
 With GitHub actions, our workflow for publishing new version to NPM are automatic! Here are the steps you need to take to ensure a release occurs:
 
-1. In a commit, update your [`package.json`](../package.json) and [`package-lock.json`](../package-lock.json) with the next version. We use [semver](https://semver.org) for versioning:
+1. In a commit, update your [`package.json`](../package.json) and [`package-lock.json`](../package-lock.json) with the next version. You can either perform this manually, or via the [NPM `version` command](https://docs.npmjs.com/cli/version):
 
-```diff
-- "version": "1.0.0",
-+ "version": "1.0.1", # minor update
-```
+   ```sh
+   npm version patch
+   # npm version minor
+   # npm version major
+   ```
+
+   or, in [`package.json`](../package.json) and [`package-lock.json`](../package-lock.json):
+
+   ```diff
+   - "version": "1.0.0",
+   + "version": "1.0.1", # patch update
+   ```
+
+   > _Note:_ We use [semver](https://semver.org) for versioning.
 
 2. Create a new pull request with the commit. Be sure to follow the steps in the [Contribute Code](#contribute-code) section.
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -220,22 +220,13 @@ TBD - need to hash out a bit more of this process.
 
 With GitHub actions, our workflow for publishing new version to NPM are automatic! Here are the steps you need to take to ensure a release occurs:
 
-1. In a commit, update your [`package.json`](../package.json) and [`package-lock.json`](../package-lock.json) with the next version. You can either perform this manually, or via the [NPM `version` command](https://docs.npmjs.com/cli/version):
+1. In a commit, use the [NPM `version` command](https://docs.npmjs.com/cli/version) to update the package to the next version:
 
    ```sh
    npm version patch
    # npm version minor
    # npm version major
    ```
-
-   or, in [`package.json`](../package.json) and [`package-lock.json`](../package-lock.json):
-
-   ```diff
-   - "version": "1.0.0",
-   + "version": "1.0.1", # patch update
-   ```
-
-   > _Note:_ We use [semver](https://semver.org) for versioning.
 
 2. Create a new pull request with the commit. Be sure to follow the steps in the [Contribute Code](#contribute-code) section.
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -18,7 +18,6 @@
   - [Review Pull Requests](#review-pull-requests)
   - [Merge Pull Requests](#merge-pull-requests)
   - [Release Workflow](#release-workflow)
-  - [Tag a Release](#tag-a-release)
 - Add a Guide Like This One [To My Project](#attribution)?
 
 ## Introduction

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -240,7 +240,7 @@ With GitHub actions, our workflow for publishing new version to NPM are automati
 
 2. Create a new pull request with the commit. Be sure to follow the steps in the [Contribute Code](#contribute-code) section.
 
-3. If the pull request is merged successfully, the `Release` action should publish the latest version to NPM and create a new release.
+3. If the pull request is merged successfully, the [`Release` action](./workflows/release.yml) should publish the latest version to NPM and create a new release.
 
 ## Attribution
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,6 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
-    if: github.event.pull_request.merged # only update on PR update
 
     steps:
       - name: Check out the branch

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,58 @@
+name: Release
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.merged # only update on PR update
+
+    steps:
+      - name: Check out the branch
+        uses: actions/checkout@v2
+
+      - name: Check if version was updated
+        id: version_check
+        uses: EndBug/version-check@master
+        with:
+          diff-search: true # searches all commit diffs if SemVer not included in commit message
+
+      - name: No update detected
+        if: steps.version_check.outputs.changed != 'true'
+        run: 'echo "No update detected! Shutting down..."' # Shut down if no version update
+
+      - name: Version update detected
+        if: steps.version_check.outputs.changed == 'true'
+        run: 'echo "Version change found! New ${{ steps.version_check.outputs.type }} version: ${{ steps.version_check.outputs.version }}"'
+
+      - name: Read .nvmrc
+        if: steps.version_check.outputs.changed == 'true'
+        id: node_version
+        run: echo ::set-output name=NODE_VERSION::$(cat .nvmrc)
+
+      - name: Setup node
+        if: steps.version_check.outputs.changed == 'true'
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ steps.node_version.outputs.NODE_VERSION }}
+
+      - name: Install dependencies
+        if: steps.version_check.outputs.changed == 'true'
+        run: npm ci
+
+      - name: Publish package to NPM
+        if: steps.version_check.outputs.changed == 'true'
+        run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Create release
+        uses: actions/create-release@latest
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: v${{ steps.version_check.outputs.version }}
+          release_name: Release v${{ steps.version_check.outputs.version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,6 +49,7 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Create release
+        if: steps.version_check.outputs.changed == 'true'
         uses: actions/create-release@latest
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > A collection of Upstatement's most-used React hooks
 
-![](https://github.com/Upstatement/react-hooks/workflows/CI/badge.svg?branch=master)
+![](https://github.com/Upstatement/react-hooks/workflows/CI/badge.svg?branch=master) [![](https://badgen.net/npm/v/@upstatement/react-hooks)](https://www.npmjs.com/package/@upstatement/react-hooks)
 
 A collection of Upstatement's most-used React hooks across projects, updated to have first-class TypeScript support!
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@upstatement/react-hooks",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@upstatement/react-hooks",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "A collection of Upstatement's most-used React hooks",
   "author": "Upstatement <tech@upstatement.com>",
   "license": "ISC",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,12 @@
   "description": "A collection of Upstatement's most-used React hooks",
   "author": "Upstatement <tech@upstatement.com>",
   "license": "ISC",
+  "keywords": [
+    "react",
+    "hooks",
+    "typescript",
+    "upstatement"
+  ],
   "main": "dist/cjs",
   "module": "dist/esm",
   "types": "dist/esm/index.d.ts",


### PR DESCRIPTION
# Description

Adds a workflow for automatically publishing to NPM and creating releases

1. Adds new `.github/workflows/release.yml` for pushes to master
    - Uses the [`EndBug/version-check`](https://github.com/EndBug/version-check) GitHub action to check for version differences
    - If a version difference was found, the package will be published using our `NPM_TOKEN` secret (found in `Settings -> Secrets` and then a new release will be created
    - If no version difference was found, the action will finish
2. Adds information about the new workflow to the `CONTRIBUTING.md` guide
3. Adds new `keywords` to `package.json` for discoverability
4. Adds NPM badge to README
5. Patch version bump to `1.0.1`
