### PR TITLE
Fixes publish workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,6 +37,7 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: ${{ steps.node_version.outputs.NODE_VERSION }}
+          registry-url: 'https://registry.npmjs.org'
 
       - name: Install dependencies
         if: steps.version_check.outputs.changed == 'true'

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@upstatement/react-hooks",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@upstatement/react-hooks",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "A collection of Upstatement's most-used React hooks",
   "author": "Upstatement <tech@upstatement.com>",
   "license": "ISC",


### PR DESCRIPTION
# Description

This fixes an issue with unauthorized publishes to NPM (error logged [here](https://github.com/Upstatement/react-hooks/runs/637012756))

- Adds `registry-url` input to the `actions/setup-node` step
    - Seen in the docs [here](https://help.github.com/en/actions/language-and-framework-guides/publishing-nodejs-packages#publishing-packages-to-the-npm-registry) and the code [here](https://github.com/actions/setup-node/blob/master/src/setup-node.ts#L32), the registry URL is required for publishing NPM packages to the registry
- Version bump to `1.0.2`